### PR TITLE
"Minimalistic" changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,16 +18,16 @@ HOST="https://cloud.example.com"
 # output of the tarpackage
 OUT="~/.cache/backup"
 
-# enter the service that is providing the dav-service (eg. "owncloud"/"baikal")
+# enter the service that is providing the dav-service (eg. "owncloud"/"baikal"/"radicale")
 SERVICE="baikal"
 
 # enter your login-username
 DAVUSER="user"
 
-# small letters (for owncloud/baikal)
+# small letters (for owncloud/baikal/radicale)
 ADDRESSBOOKS=("private" "work")
 
-# small letters (for owncloud/baikal)
+# small letters (for owncloud/baikal/radicale)
 CALENDARS=("personal" "holiday")
 
 # date-format of output-file

--- a/README.md
+++ b/README.md
@@ -25,11 +25,10 @@ SERVICE="baikal"
 DAVUSER="user"
 
 # small letters (for owncloud/baikal)
-ADDRESSBOOK="contacts"
+ADDRESSBOOKS=("private" "work")
 
 # small letters (for owncloud/baikal)
-CALENDAR="personal
-holiday"
+CALENDARS=("personal" "holiday")
 
 # date-format of output-file
 DATE=$(date +"%Y-%m-%d_%H-%M-%S")

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ CALENDARS=("personal" "holiday")
 DATE=$(date +"%Y-%m-%d_%H-%M-%S")
 ```
 
+For `ADDRESSBOOKS` and `CALENDARS`, also values of the format `<id>:<name>` are allowed, while `<id>` is the identifier of your server and `<name>` is used in the filename.
 
 ## credentials
 

--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@ SERVICE="baikal"
 # enter your login-username
 DAVUSER="user"
 
-# leave it empty, then you will be promted every time you use the script
-PASSWORD="123456"
-
 # small letters (for owncloud/baikal)
 ADDRESSBOOK="contacts"
 
@@ -27,5 +24,16 @@ holiday"
 
 # date-format of output-file
 DATE=$(date +"%Y_%m_%d_%H_%M_%S")
+
+```
+
+Also put your credentials into `~/.config/dav-backup/credentials`:
+
+```
+# put into
+#~/.config/dav-backup/credentials
+
+user=<Value of DAVUSER>
+password=<your password to authenticate>
 
 ```

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ you can configure your data in a config file for automation:
 # the URL to your server
 HOST="https://cloud.example.com"
 
+# output of the tarpackage
+OUT="~/.cache/backup"
+
 # enter the service that is providing the dav-service (eg. "owncloud"/"baikal")
 SERVICE="baikal"
 

--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ CALENDAR="personal
 holiday"
 
 # date-format of output-file
-DATE=$(date +"%Y_%m_%d_%H_%M_%S")
-
+DATE=$(date +"%Y-%m-%d_%H-%M-%S")
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ is a simple script, that downloads all your calendars and contacts from owncloud
 you can configure your data in a config file for automation:
 ```
 #dav-backup
+#~/.config/dav-backup/config
 
 # the URL to your server
 HOST="https://cloud.example.com"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
-#dav-backup
-is a simple script, that downloads all your calendars and contacts from owncloud and stores them in a file
+# dav-backup
 
-you can configure your data in a config file for automation:
+A simple script, that downloads all your calendars and addressbooks from owncloud or baikal and stores them in a file.
+
+# configuration
+
+## main
+
+You can configure your data in a config file for automation:
+
 ```
 #dav-backup
 #~/.config/dav-backup/config
@@ -29,6 +35,9 @@ holiday"
 DATE=$(date +"%Y_%m_%d_%H_%M_%S")
 
 ```
+
+
+## credentials
 
 Also put your credentials into `~/.config/dav-backup/credentials`:
 

--- a/config-example
+++ b/config-example
@@ -10,11 +10,10 @@ SERVICE="baikal"
 DAVUSER="user"
 
 # small letters (for owncloud/baikal)
-ADDRESSBOOK="contacts"
+ADDRESSBOOKS=("private" "work")
 
 # small letters (for owncloud/baikal)
-CALENDAR="personal
-holiday"
+CALENDARS=("personal" "holiday")
 
 # date-format of output-file
 DATE=$(date +"%Y-%m-%d_%H-%M-%S")

--- a/config-example
+++ b/config-example
@@ -17,4 +17,4 @@ CALENDAR="personal
 holiday"
 
 # date-format of output-file
-DATE=$(date +"%Y_%m_%d_%H_%M_%S")
+DATE=$(date +"%Y-%m-%d_%H-%M-%S")

--- a/config-example
+++ b/config-example
@@ -3,16 +3,16 @@
 # the URL to your server
 HOST="https://cloud.example.com"
 
-# enter the service that is providing the dav-service (eg. "owncloud"/"baikal")
+# enter the service that is providing the dav-service (eg. "owncloud"/"baikal"/"radicale")
 SERVICE="baikal"
 
 # enter your login-username
 DAVUSER="user"
 
-# small letters (for owncloud/baikal)
+# small letters (for owncloud/baikal/radicale)
 ADDRESSBOOKS=("private" "work")
 
-# small letters (for owncloud/baikal)
+# small letters (for owncloud/baikal/radicale)
 CALENDARS=("personal" "holiday")
 
 # date-format of output-file

--- a/config-example
+++ b/config-example
@@ -9,9 +9,6 @@ SERVICE="baikal"
 # enter your login-username
 DAVUSER="user"
 
-# leave it empty, then you will be promted every time you use the script
-PASSWORD="123456"
-
 # small letters (for owncloud/baikal)
 ADDRESSBOOK="contacts"
 

--- a/credentials
+++ b/credentials
@@ -1,0 +1,11 @@
+# put into
+#~/.config/dav-backup/credentials
+
+user=<Value of DAVUSER>
+password=<your password to authenticate>
+
+# If you want to get asked for your password every time,
+# uncomment the following
+#ask-password
+
+# Any other commands for wget work here

--- a/dav-backup.sh
+++ b/dav-backup.sh
@@ -14,12 +14,12 @@ tar cfT "$OUT/DAV-$DATE.tar.gz" /dev/null
 
 case "$SERVICE" in
 	"owncloud" )
-		CARDURL="remote.php/carddav/addressbooks"
-		CALURL="remote.php/caldav/calendars"
+		CARDURL="$HOST/remote.php/carddav/addressbooks/$DAVUSER/%s?export"
+		CALURL="$HOST/remote.php/caldav/calendars/$DAVUSER/%s?export"
 		;;
 	"baikal" )
-		CARDURL="dav.php/addressbooks"
-		CALURL="dav.php/calendars"
+		CARDURL="$HOST/dav.php/addressbooks/$DAVUSER/%s?export"
+		CALURL="$HOST/dav.php/calendars/$DAVUSER/%s?export"
 		;;
 	*)
 		echo "Unknown Service"
@@ -29,7 +29,7 @@ esac
 for addr in $ADDRESSBOOK; do
 	wget -q \
 		-O $OUT/${addr}-$DATE.vcf \
-		$HOST/$CARDURL/$DAVUSER/$addr?export
+		"$(printf "${CARDURL}" "${addr}")"
 	
 	if [ -s $OUT/$addr-$DATE.vcf ]; then
 		echo "$addr successfully downloaded"
@@ -46,7 +46,7 @@ done
 for cal in $CALENDAR; do
 	wget -q \
 		-O $OUT/$cal-$DATE.ics \
-		$HOST/$CALURL/$DAVUSER/$cal?export
+		"$(printf "${CALURL}" "${cal}")"
 	
 	if [ -s $OUT/$cal-$DATE.ics ]; then
 		echo "$cal successfully downloaded"

--- a/dav-backup.sh
+++ b/dav-backup.sh
@@ -1,12 +1,33 @@
 #!/bin/bash
 
+die() { echo "$*" >&2; exit 1; }
+
+# download first argument and put with filename of argument two into archive
+download(){
+
+	url="${1?No URL given to download.}"
+	file="${2?No filename given to save.}"
+
+	wget -q \
+		-O "$OUT/${file}" \
+		"${url}"
+
+	if [ -s "$OUT/$file" ]; then
+		echo "SUCCESS: $file"
+	else
+		die "Unknown Error at '${file}'!"
+	fi
+
+	tar r -C "$OUT" -f "$OUT/DAV-$DATE.tar.gz" "${file}"
+	rm "$OUT/${file}"
+}
+
 # getting config
 source "${XDG_CONFIG_HOME:-$HOME/.config}/dav-backup/config"
 export WGETRC="${XDG_CONFIG_HOME:-$HOME/.config}/dav-backup/credentials"
 
 if [[ ! -w "$OUT/" ]]; then
-	echo "Error: unable to write into directory '${OUT}'!"
-	exit 1
+	die "Error: unable to write into directory '${OUT}'!"
 fi
 
 # create empty tarpackage
@@ -22,8 +43,7 @@ case "$SERVICE" in
 		CALURL="$HOST/dav.php/calendars/$DAVUSER/%s?export"
 		;;
 	*)
-		echo "Unknown Service"
-		exit 1
+		die "Unknown Service"
 esac
 
 for addr in "${ADDRESSBOOKS[@]}"; do
@@ -31,20 +51,7 @@ for addr in "${ADDRESSBOOKS[@]}"; do
 	IFS=: read id name <<< "${addr}"
 	[ -n "${name}" ] || name="${id}"
 
-	wget -q \
-		-O "$OUT/${name}-$DATE.vcf" \
-		"$(printf "${CARDURL}" "${id}")"
-	
-	if [ -s "$OUT/$name-$DATE.vcf" ]; then
-		echo "$name successfully downloaded"
-	else
-		echo "unknwon error"
-		rm "$OUT/$name-$DATE.vcf"
-		exit $?
-	fi
-
-	tar r -C "$OUT" -f "$OUT/DAV-$DATE.tar.gz" "$name-$DATE.vcf"
-	rm "$OUT/$name-$DATE.vcf"
+	download "$(printf "${CARDURL}" "${id}")" "${name}-$DATE.vcf"
 done
 
 for cal in "${CALENDARS[@]}"; do
@@ -52,18 +59,5 @@ for cal in "${CALENDARS[@]}"; do
 	IFS=: read id name <<< "${cal}"
 	[ -n "${name}" ] || name="${id}"
 
-	wget -q \
-		-O "$OUT/$name-$DATE.ics" \
-		"$(printf "${CALURL}" "${id}")"
-	
-	if [ -s "$OUT/$name-$DATE.ics" ]; then
-		echo "$name successfully downloaded"
-	else
-		echo "unknwon error"
-		rm "$OUT/$name-$DATE.ics"
-		exit $?
-	fi
-
-	tar r -C "$OUT" -f "$OUT/DAV-$DATE.tar.gz" "$name-$DATE.ics"
-	rm "$OUT/$name-$DATE.ics"
+	download "$(printf "${CALURL}" "${id}")" "$name-$DATE.ics"
 done

--- a/dav-backup.sh
+++ b/dav-backup.sh
@@ -42,6 +42,10 @@ case "$SERVICE" in
 		CARDURL="$HOST/dav.php/addressbooks/$DAVUSER/%s?export"
 		CALURL="$HOST/dav.php/calendars/$DAVUSER/%s?export"
 		;;
+	"radicale" )
+		CARDURL="$HOST/$DAVUSER/%s"
+		CALURL="${CARDURL}"
+		;;
 	*)
 		die "Unknown Service"
 esac

--- a/dav-backup.sh
+++ b/dav-backup.sh
@@ -31,7 +31,7 @@ fi
 
 
 for addr in $ADDRESSBOOK; do
-	wget --user="$DAVUSER" --password="$PASSWORD" --no-check-certificate --recursive -q -O ${addr}-$DATE.vcf $HOST/$CARDURL/$DAVUSER/$addr?export
+	wget --user="$DAVUSER" --password="$PASSWORD" -q -O ${addr}-$DATE.vcf $HOST/$CARDURL/$DAVUSER/$addr?export
 	
 	if [ -s $addr-$DATE.vcf ]; then
 		echo "$addr successfully downloaded"
@@ -46,7 +46,7 @@ for addr in $ADDRESSBOOK; do
 done
 
 for cal in $CALENDAR; do
-	wget --user="$DAVUSER" --password="$PASSWORD" --no-check-certificate --recursive -q -O $cal-$DATE.ics $HOST/$CALURL/$DAVUSER/$cal?export
+	wget --user="$DAVUSER" --password="$PASSWORD" -q -O $cal-$DATE.ics $HOST/$CALURL/$DAVUSER/$cal?export
 	
 	if [ -s $cal-$DATE.ics ]; then
 		echo "$cal successfully downloaded"

--- a/dav-backup.sh
+++ b/dav-backup.sh
@@ -26,7 +26,7 @@ case "$SERVICE" in
 		exit 1
 esac
 
-for addr in "$ADDRESSBOOK"; do
+for addr in "${ADDRESSBOOKS[@]}"; do
 	wget -q \
 		-O "$OUT/${addr}-$DATE.vcf" \
 		"$(printf "${CARDURL}" "${addr}")"
@@ -43,7 +43,7 @@ for addr in "$ADDRESSBOOK"; do
 	rm "$OUT/$addr-$DATE.vcf"
 done
 
-for cal in "$CALENDAR"; do
+for cal in "${CALENDARS[@]}"; do
 	wget -q \
 		-O "$OUT/$cal-$DATE.ics" \
 		"$(printf "${CALURL}" "${cal}")"

--- a/dav-backup.sh
+++ b/dav-backup.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
 
-if [[ ! -w ./ ]]; then
-	echo "Error: unable to write in directory"
-	exit 1
-fi
-
 # getting config
 source "${XDG_CONFIG_HOME:-$HOME/.config}/dav-backup/config"
 export WGETRC="${XDG_CONFIG_HOME:-$HOME/.config}/dav-backup/credentials"
 
-tar cfT DAV-$DATE.tar.gz /dev/null
+if [[ ! -w $OUT/ ]]; then
+	echo "Error: unable to write into directory '${OUT}'!"
+	exit 1
+fi
+
+# create empty tarpackage
+tar cfT "$OUT/DAV-$DATE.tar.gz" /dev/null
 
 case "$SERVICE" in
 	"owncloud" )
@@ -27,34 +28,34 @@ esac
 
 for addr in $ADDRESSBOOK; do
 	wget -q \
-		-O ${addr}-$DATE.vcf \
+		-O $OUT/${addr}-$DATE.vcf \
 		$HOST/$CARDURL/$DAVUSER/$addr?export
 	
-	if [ -s $addr-$DATE.vcf ]; then
+	if [ -s $OUT/$addr-$DATE.vcf ]; then
 		echo "$addr successfully downloaded"
 	else
 		echo "unknwon error"
-		rm $addr-$DATE.vcf
+		rm $OUT/$addr-$DATE.vcf
 		exit $?
 	fi
 
-	tar rvf DAV-$DATE.tar.gz $addr-$DATE.vcf
-	rm $addr-$DATE.vcf
+	tar r -C $OUT -f $OUT/DAV-$DATE.tar.gz $addr-$DATE.vcf
+	rm $OUT/$addr-$DATE.vcf
 done
 
 for cal in $CALENDAR; do
 	wget -q \
-		-O $cal-$DATE.ics \
+		-O $OUT/$cal-$DATE.ics \
 		$HOST/$CALURL/$DAVUSER/$cal?export
 	
-	if [ -s $cal-$DATE.ics ]; then
+	if [ -s $OUT/$cal-$DATE.ics ]; then
 		echo "$cal successfully downloaded"
 	else
 		echo "unknwon error"
-		rm $cal-$DATE.ics
+		rm $OUT/$cal-$DATE.ics
 		exit $?
 	fi
 
-	tar rvf DAV-$DATE.tar.gz $cal-$DATE.ics
-	rm $cal-$DATE.ics
+	tar r -C $OUT -f $OUT/DAV-$DATE.tar.gz $cal-$DATE.ics
+	rm $OUT/$cal-$DATE.ics
 done

--- a/dav-backup.sh
+++ b/dav-backup.sh
@@ -30,34 +30,34 @@ if [[ -z "$PASSWORD" ]]; then
 fi
 
 
-for i in $ADDRESSBOOK; do
-	wget --user="$DAVUSER" --password="$PASSWORD" --no-check-certificate --recursive -q -O $i-$DATE.vcf $HOST/$CARDURL/$DAVUSER/$i?export
+for addr in $ADDRESSBOOK; do
+	wget --user="$DAVUSER" --password="$PASSWORD" --no-check-certificate --recursive -q -O ${addr}-$DATE.vcf $HOST/$CARDURL/$DAVUSER/$addr?export
 	
-	if [ -s $i-$DATE.vcf ]; then
-		echo "$i successfully downloaded"
+	if [ -s $addr-$DATE.vcf ]; then
+		echo "$addr successfully downloaded"
 	else
 		echo "unknwon error"
-		rm $i-$DATE.vcf
+		rm $addr-$DATE.vcf
 		exit $?
 	fi
 
-	tar rvf DAV-$DATE.tar.gz $i-$DATE.vcf
-	rm $i-$DATE.vcf
+	tar rvf DAV-$DATE.tar.gz $addr-$DATE.vcf
+	rm $addr-$DATE.vcf
 done
 
-for j in $CALENDAR; do
-	wget --user="$DAVUSER" --password="$PASSWORD" --no-check-certificate --recursive -q -O $j-$DATE.ics $HOST/$CALURL/$DAVUSER/$j?export
+for cal in $CALENDAR; do
+	wget --user="$DAVUSER" --password="$PASSWORD" --no-check-certificate --recursive -q -O $cal-$DATE.ics $HOST/$CALURL/$DAVUSER/$cal?export
 	
-	if [ -s $j-$DATE.ics ]; then
-		echo "$j successfully downloaded"
+	if [ -s $cal-$DATE.ics ]; then
+		echo "$cal successfully downloaded"
 	else
 		echo "unknwon error"
-		rm $j-$DATE.ics
+		rm $cal-$DATE.ics
 		exit $?
 	fi
 
-	tar rvf DAV-$DATE.tar.gz $j-$DATE.ics
-	rm $j-$DATE.ics
+	tar rvf DAV-$DATE.tar.gz $cal-$DATE.ics
+	rm $cal-$DATE.ics
 done
 
 unset PASSWORD

--- a/dav-backup.sh
+++ b/dav-backup.sh
@@ -4,7 +4,7 @@
 source "${XDG_CONFIG_HOME:-$HOME/.config}/dav-backup/config"
 export WGETRC="${XDG_CONFIG_HOME:-$HOME/.config}/dav-backup/credentials"
 
-if [[ ! -w $OUT/ ]]; then
+if [[ ! -w "$OUT/" ]]; then
 	echo "Error: unable to write into directory '${OUT}'!"
 	exit 1
 fi
@@ -26,36 +26,36 @@ case "$SERVICE" in
 		exit 1
 esac
 
-for addr in $ADDRESSBOOK; do
+for addr in "$ADDRESSBOOK"; do
 	wget -q \
-		-O $OUT/${addr}-$DATE.vcf \
+		-O "$OUT/${addr}-$DATE.vcf" \
 		"$(printf "${CARDURL}" "${addr}")"
 	
-	if [ -s $OUT/$addr-$DATE.vcf ]; then
+	if [ -s "$OUT/$addr-$DATE.vcf" ]; then
 		echo "$addr successfully downloaded"
 	else
 		echo "unknwon error"
-		rm $OUT/$addr-$DATE.vcf
+		rm "$OUT/$addr-$DATE.vcf"
 		exit $?
 	fi
 
-	tar r -C $OUT -f $OUT/DAV-$DATE.tar.gz $addr-$DATE.vcf
-	rm $OUT/$addr-$DATE.vcf
+	tar r -C "$OUT" -f "$OUT/DAV-$DATE.tar.gz" "$addr-$DATE.vcf"
+	rm "$OUT/$addr-$DATE.vcf"
 done
 
-for cal in $CALENDAR; do
+for cal in "$CALENDAR"; do
 	wget -q \
-		-O $OUT/$cal-$DATE.ics \
+		-O "$OUT/$cal-$DATE.ics" \
 		"$(printf "${CALURL}" "${cal}")"
 	
-	if [ -s $OUT/$cal-$DATE.ics ]; then
+	if [ -s "$OUT/$cal-$DATE.ics" ]; then
 		echo "$cal successfully downloaded"
 	else
 		echo "unknwon error"
-		rm $OUT/$cal-$DATE.ics
+		rm "$OUT/$cal-$DATE.ics"
 		exit $?
 	fi
 
-	tar r -C $OUT -f $OUT/DAV-$DATE.tar.gz $cal-$DATE.ics
-	rm $OUT/$cal-$DATE.ics
+	tar r -C "$OUT" -f "$OUT/DAV-$DATE.tar.gz" "$cal-$DATE.ics"
+	rm "$OUT/$cal-$DATE.ics"
 done

--- a/dav-backup.sh
+++ b/dav-backup.sh
@@ -25,13 +25,16 @@ case "$SERVICE" in
 esac
 
 if [[ -z "$PASSWORD" ]]; then
-	echo -n "Enter host password for user '$DAVUSER':"
-	read -s PASSWORD
+	read -p "Enter host password for user '$DAVUSER':" -s PASSWORD
 fi
 
 
 for addr in $ADDRESSBOOK; do
-	wget --user="$DAVUSER" --password="$PASSWORD" -q -O ${addr}-$DATE.vcf $HOST/$CARDURL/$DAVUSER/$addr?export
+	wget -q \
+		--user="$DAVUSER" \
+		--password="$PASSWORD" \
+		-O ${addr}-$DATE.vcf \
+		$HOST/$CARDURL/$DAVUSER/$addr?export
 	
 	if [ -s $addr-$DATE.vcf ]; then
 		echo "$addr successfully downloaded"
@@ -46,7 +49,11 @@ for addr in $ADDRESSBOOK; do
 done
 
 for cal in $CALENDAR; do
-	wget --user="$DAVUSER" --password="$PASSWORD" -q -O $cal-$DATE.ics $HOST/$CALURL/$DAVUSER/$cal?export
+	wget -q \
+		--user="$DAVUSER" \
+		--password="$PASSWORD" \
+		-O $cal-$DATE.ics \
+		$HOST/$CALURL/$DAVUSER/$cal?export
 	
 	if [ -s $cal-$DATE.ics ]; then
 		echo "$cal successfully downloaded"

--- a/dav-backup.sh
+++ b/dav-backup.sh
@@ -6,7 +6,7 @@ if [[ ! -w ./ ]]; then
 fi
 
 # getting config
-source ./config
+source "${XDG_CONFIG_HOME:-$HOME/.config}/dav-backup/config"
 
 tar cfT DAV-$DATE.tar.gz /dev/null
 

--- a/dav-backup.sh
+++ b/dav-backup.sh
@@ -27,35 +27,43 @@ case "$SERVICE" in
 esac
 
 for addr in "${ADDRESSBOOKS[@]}"; do
+
+	IFS=: read id name <<< "${addr}"
+	[ -n "${name}" ] || name="${id}"
+
 	wget -q \
-		-O "$OUT/${addr}-$DATE.vcf" \
-		"$(printf "${CARDURL}" "${addr}")"
+		-O "$OUT/${name}-$DATE.vcf" \
+		"$(printf "${CARDURL}" "${id}")"
 	
-	if [ -s "$OUT/$addr-$DATE.vcf" ]; then
-		echo "$addr successfully downloaded"
+	if [ -s "$OUT/$name-$DATE.vcf" ]; then
+		echo "$name successfully downloaded"
 	else
 		echo "unknwon error"
-		rm "$OUT/$addr-$DATE.vcf"
+		rm "$OUT/$name-$DATE.vcf"
 		exit $?
 	fi
 
-	tar r -C "$OUT" -f "$OUT/DAV-$DATE.tar.gz" "$addr-$DATE.vcf"
-	rm "$OUT/$addr-$DATE.vcf"
+	tar r -C "$OUT" -f "$OUT/DAV-$DATE.tar.gz" "$name-$DATE.vcf"
+	rm "$OUT/$name-$DATE.vcf"
 done
 
 for cal in "${CALENDARS[@]}"; do
+
+	IFS=: read id name <<< "${cal}"
+	[ -n "${name}" ] || name="${id}"
+
 	wget -q \
-		-O "$OUT/$cal-$DATE.ics" \
-		"$(printf "${CALURL}" "${cal}")"
+		-O "$OUT/$name-$DATE.ics" \
+		"$(printf "${CALURL}" "${id}")"
 	
-	if [ -s "$OUT/$cal-$DATE.ics" ]; then
-		echo "$cal successfully downloaded"
+	if [ -s "$OUT/$name-$DATE.ics" ]; then
+		echo "$name successfully downloaded"
 	else
 		echo "unknwon error"
-		rm "$OUT/$cal-$DATE.ics"
+		rm "$OUT/$name-$DATE.ics"
 		exit $?
 	fi
 
-	tar r -C "$OUT" -f "$OUT/DAV-$DATE.tar.gz" "$cal-$DATE.ics"
-	rm "$OUT/$cal-$DATE.ics"
+	tar r -C "$OUT" -f "$OUT/DAV-$DATE.tar.gz" "$name-$DATE.ics"
+	rm "$OUT/$name-$DATE.ics"
 done

--- a/dav-backup.sh
+++ b/dav-backup.sh
@@ -7,6 +7,7 @@ fi
 
 # getting config
 source "${XDG_CONFIG_HOME:-$HOME/.config}/dav-backup/config"
+export WGETRC="${XDG_CONFIG_HOME:-$HOME/.config}/dav-backup/credentials"
 
 tar cfT DAV-$DATE.tar.gz /dev/null
 
@@ -24,15 +25,8 @@ case "$SERVICE" in
 		exit 1
 esac
 
-if [[ -z "$PASSWORD" ]]; then
-	read -p "Enter host password for user '$DAVUSER':" -s PASSWORD
-fi
-
-
 for addr in $ADDRESSBOOK; do
 	wget -q \
-		--user="$DAVUSER" \
-		--password="$PASSWORD" \
 		-O ${addr}-$DATE.vcf \
 		$HOST/$CARDURL/$DAVUSER/$addr?export
 	
@@ -50,8 +44,6 @@ done
 
 for cal in $CALENDAR; do
 	wget -q \
-		--user="$DAVUSER" \
-		--password="$PASSWORD" \
 		-O $cal-$DATE.ics \
 		$HOST/$CALURL/$DAVUSER/$cal?export
 	
@@ -66,5 +58,3 @@ for cal in $CALENDAR; do
 	tar rvf DAV-$DATE.tar.gz $cal-$DATE.ics
 	rm $cal-$DATE.ics
 done
-
-unset PASSWORD


### PR DESCRIPTION
- don't rely on the current work directory (use ~/.config at best)
- Do not put the password on the cmdline (use wgetrc for this!)
- consistently double quote every variable
- have an $OUT specifier to point where to put the export files
- Use an additonal name field: id and name for calendar servers, which do not support easy names.